### PR TITLE
feat: init scheduler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,135 @@
+version: 2.1
+
+executors:
+  default:
+    machine:
+      image: ubuntu-1604-cuda-10.1:201909-23
+    working_directory: ~/gpuci
+    resource_class: gpu.nvidia.medium
+
+restore-workspace: &restore-workspace
+  attach_workspace:
+    at: ~/
+
+restore-cache: &restore-cache
+  restore_cache:
+    keys:
+      - cargo-v0-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - repo-source-{{ .Branch }}-{{ .Revision }}
+
+commands:
+  test_target:
+    parameters:
+      target:
+        type: string
+    steps:
+      - *restore-workspace
+      - *restore-cache
+      - run:
+          name: Test (<< parameters.target >>)
+          command: TARGET=<< parameters.target >> cargo test
+          no_output_timeout: 15m
+
+jobs:
+
+  cargo_fetch:
+    executor: default
+    steps:
+      - checkout
+      - run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
+      - run: echo $BASH_ENV
+      - run: echo $HOME
+      - run: source $BASH_ENV
+      - run: cargo --version
+      - run: rustc --version
+      - run:
+          name: Update submodules
+          command: git submodule update --init --recursive
+      - run:
+          name: Calculate dependencies
+          command: cargo generate-lockfile
+      - restore_cache:
+          keys:
+            - cargo-v0-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - run: cargo update
+      - run: cargo fetch
+      - run: rustup install $(cat rust-toolchain)
+      - run: rustup default $(cat rust-toolchain)
+      - run: rustup component add rustfmt-preview
+      - run: rustup component add clippy-preview
+      - run: rustc --version
+      - run: rm -rf .git
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - gpuci
+      - save_cache:
+          key: cargo-v0-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          paths:
+            - "~/.cargo"
+            - "~/.rustup"
+
+  test_x86_64-unknown-linux-gnu:
+    executor: default
+    steps:
+      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
+      - run: source $BASH_ENV
+      - run: sudo apt-get update -y
+      - run: apt-cache search opencl
+      - run: sudo apt install -y ocl-icd-opencl-dev
+      - test_target:
+          target: "x86_64-unknown-linux-gnu"
+
+  rustfmt:
+    executor: default
+    steps:
+      - *restore-workspace
+      - *restore-cache
+      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
+      - run: source $BASH_ENV
+      - run:
+          name: Run cargo fmt
+          command: cargo fmt --all -- --check
+
+  clippy:
+    executor: default
+    steps:
+      - *restore-workspace
+      - *restore-cache
+      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
+      - run: source $BASH_ENV
+      - run:
+          name: Run cargo clippy
+          command: cargo clippy --all-features
+
+  build:
+    executor: default
+    steps:
+      - *restore-workspace
+      - *restore-cache
+      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
+      - run: source $BASH_ENV
+      - run:
+          name: Run cargo release build
+          command: cargo build --release
+
+
+workflows:
+  version: 2.1
+
+  test:
+    jobs:
+      - cargo_fetch
+      - rustfmt:
+          requires:
+            - cargo_fetch
+      - clippy:
+          requires:
+            - cargo_fetch
+      - test_x86_64-unknown-linux-gnu:
+          requires:
+            - cargo_fetch
+      - build:
+          requires:
+            - cargo_fetch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,14 @@ ocl = { version = "0.19.4", package = "fil-ocl" }
 dirs = "2.0.2"
 sha2 = "0.8.2"
 thiserror = "1.0.10"
+fs2 = { version = "0.4.3", optional = true }
+lazy_static = "1.4.0"
+log = "0.4.8"
+rand = "0.7.3"
+
+[dev-dependencies]
+env_logger = "0.7.0"
+
+[features]
+default = ["scheduler"]
+scheduler = ["fs2"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod multigpu;
 pub mod opencl;

--- a/src/multigpu/error.rs
+++ b/src/multigpu/error.rs
@@ -1,0 +1,9 @@
+#[derive(thiserror::Error, Debug)]
+pub enum SchedulerError {
+    #[error("Cannot parse task file!")]
+    ParseError,
+    #[error("IO Error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+pub type SchedulerResult<T> = std::result::Result<T, SchedulerError>;

--- a/src/multigpu/mod.rs
+++ b/src/multigpu/mod.rs
@@ -1,0 +1,206 @@
+mod error;
+mod task;
+mod utils;
+
+use crate::opencl::*;
+pub use error::*;
+use fs2::FileExt;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::thread;
+use std::time::Duration;
+pub use task::*;
+
+pub trait Resource {
+    // Each resource should have a unique identifier
+    fn id(&self) -> String;
+}
+
+impl Resource for Device {
+    fn id(&self) -> String {
+        format!("GPU-{}", self.bus_id())
+    }
+}
+
+pub struct Scheduler<R: Resource> {
+    root: PathBuf,
+    polling: Duration,
+    resources: Vec<R>,
+}
+
+impl<R: Resource> Scheduler<R> {
+    pub fn new(
+        root: PathBuf,
+        polling: Duration,
+        resources: Vec<R>,
+    ) -> SchedulerResult<Scheduler<R>> {
+        // Create subdirectories for all of the resources
+        for resource in resources.iter() {
+            fs::create_dir_all(root.join(resource.id()))?;
+        }
+
+        Ok(Scheduler {
+            root,
+            polling,
+            resources,
+        })
+    }
+
+    // Returns all tasks that are queued on the given resource by examining its
+    // subdirectory.
+    fn tasks_of(&self, resource: &R) -> SchedulerResult<Vec<Task>> {
+        let resource_path = self.root.join(resource.id());
+
+        Ok(fs::read_dir(&resource_path)?
+            .filter_map(|res| res.ok())
+            // We only consider locked files as real tasks. Those that are
+            // unlocked are either dead (Because of a crash or failure) or
+            // not fully initialized.
+            .filter(|dir| {
+                fs::File::create(dir.path())
+                    .map(|f| f.try_lock_exclusive().is_err())
+                    .unwrap_or(false)
+            })
+            // Deserialize file names to Tasks
+            .filter_map(|dir| {
+                dir.file_name()
+                    .into_string()
+                    .ok()
+                    .and_then(|name| Task::from_str(&name).ok())
+            })
+            .collect::<Vec<_>>())
+    }
+
+    // Schedule `f` on one of the `self.resources`
+    pub fn schedule<F, T>(&mut self, task: Task, f: F) -> SchedulerResult<T>
+    where
+        F: FnOnce(&R) -> T,
+    {
+        // We will keep all of our locked task files here, so that whenever `schedule` function
+        // is exited (Peacefully, or because of an error/crash), all of its associated Task files
+        // (And thus their locks) are dropped automatically and they no longer will be considered
+        // as active tasks and won't show up when `tasks_of()` is called.
+        let mut lock_files = HashMap::<PathBuf, fs::File>::new();
+
+        loop {
+            // Check if we can find a free device before enqueueing task files.
+            for resource in self.resources.iter() {
+                let tasks = self.tasks_of(resource)?;
+                if task.has_priority_over(&tasks) {
+                    // Although the given task has priority over all of the tasks currently queued
+                    // on the resource, we can't use it until the corresponding lock file of that
+                    // device is free. (I.e we can have the priority, but it doesn't mean that the
+                    // lower-priority Task has released the resource yet)
+                    // Having a separate lock-file for the resource, gives us the guarantee that
+                    // no two tasks can use the resource at the same time.
+                    let resource_lock_path = self.root.join(resource.id()).join("LOCK");
+                    match fs::File::create(resource_lock_path)?.try_lock_exclusive() {
+                        Ok(lock) => {
+                            // This is not needed, and it's just for the purpose of keeping
+                            // our scheduler directory clean.
+                            for (path, _) in lock_files.iter() {
+                                fs::remove_file(path)?;
+                            }
+
+                            let result = f(resource);
+                            drop(lock);
+                            return Ok(result);
+                        }
+                        Err(_) => {
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            // No free devices found! Enqueue the task into all of the devices.
+            for resource in self.resources.iter() {
+                let task_path = self.root.join(resource.id()).join(&task.to_string());
+
+                if !lock_files.contains_key(&task_path) {
+                    let f = fs::File::create(&task_path)?;
+                    f.lock_exclusive()?;
+                    lock_files.insert(task_path, f);
+                }
+            }
+
+            thread::sleep(self.polling);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use log::*;
+    use rand::seq::SliceRandom;
+    use rand::thread_rng;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug, Clone)]
+    struct DummyResource {
+        id: usize,
+    }
+
+    impl Resource for DummyResource {
+        fn id(&self) -> String {
+            format!("Dummy-{}", self.id)
+        }
+    }
+
+    #[test]
+    fn test_program_pool() {
+        let _ = env_logger::try_init();
+
+        let rng = &mut thread_rng();
+
+        const NUM_RESOURCES: usize = 3;
+        const NUM_TASKS: usize = 30;
+
+        let order = Arc::new(Mutex::new(Vec::new()));
+
+        let resources = (0..NUM_RESOURCES)
+            .map(|i| DummyResource { id: i })
+            .collect::<Vec<_>>();
+
+        // Create `NUM_TASKS` tasks all with different priorities and shuffle them.
+        let mut tasks = (0..NUM_TASKS)
+            .map(|i| Task::new(format!("Task{}", i), i as usize))
+            .collect::<Vec<_>>();
+        tasks.shuffle(rng);
+
+        let mut threads = Vec::new();
+        for t in tasks {
+            let order = Arc::clone(&order);
+            let resources = resources.clone();
+            threads.push(thread::spawn(move || {
+                let mut pool = Scheduler::<DummyResource>::new(
+                    "/tmp/gpus".into(),
+                    Duration::from_millis(100),
+                    resources.clone(),
+                )
+                .unwrap();
+                pool.schedule(t.clone(), |resource| {
+                    info!("Task {} scheduled on {}!", t.id, resource.id());
+                    if let Ok(mut order) = order.lock() {
+                        order.push(t.priority);
+                    }
+                    thread::sleep(Duration::from_millis(500));
+                })
+                .unwrap();
+            }));
+        }
+
+        for t in threads {
+            t.join().unwrap();
+        }
+
+        let order = order.lock().unwrap()[NUM_RESOURCES..].to_vec();
+        let mut sorted_order = order.clone();
+        sorted_order.sort();
+
+        assert_eq!(order, sorted_order);
+    }
+}

--- a/src/multigpu/task.rs
+++ b/src/multigpu/task.rs
@@ -1,0 +1,54 @@
+use super::*;
+
+// When `Ord` is derived on structs, it will produce a lexicographic ordering based on
+// the top-to-bottom declaration order of the struct's members. Thus first based on
+// `priority`, then `timestamp`.
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Task {
+    pub(super) priority: usize,
+    pub(super) timestamp: u64,
+    pub(super) id: String,
+}
+
+impl Task {
+    pub fn new(id: String, priority: usize) -> Task {
+        Task {
+            id,
+            priority,
+            timestamp: utils::timestamp(),
+        }
+    }
+
+    // Returns true if the task has higher priority over all of the given `tasks` based
+    // on `priority` and `timestamp`.
+    pub fn has_priority_over(&self, tasks: &Vec<Task>) -> bool {
+        let mut sorted = tasks.clone();
+        sorted.push(self.clone());
+        sorted.sort();
+        sorted[0] == *self
+    }
+}
+
+// Serialize to a file name
+impl ToString for Task {
+    fn to_string(&self) -> String {
+        format!("{}-{}-{}", self.priority, self.timestamp, self.id)
+    }
+}
+
+// Deserialize from a file name
+impl std::str::FromStr for Task {
+    type Err = SchedulerError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<_> = s.split("-").collect();
+        if parts.len() != 3 {
+            return Err(SchedulerError::ParseError);
+        }
+        Ok(Task {
+            priority: usize::from_str(parts[0]).map_err(|_| SchedulerError::ParseError)?,
+            timestamp: u64::from_str(parts[1]).map_err(|_| SchedulerError::ParseError)?,
+            id: parts[2].into(),
+        })
+    }
+}

--- a/src/multigpu/utils.rs
+++ b/src/multigpu/utils.rs
@@ -1,0 +1,7 @@
+// UNIX epoch is milliseconds
+pub fn timestamp() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}

--- a/src/opencl/mod.rs
+++ b/src/opencl/mod.rs
@@ -88,6 +88,9 @@ impl Device {
     pub fn is_little_endian(&self) -> GPUResult<bool> {
         Ok(utils::is_little_endian(self.device)?)
     }
+    pub fn bus_id(&self) -> BusId {
+        self.bus_id
+    }
 
     pub fn all() -> GPUResult<Vec<Device>> {
         let mut all = Vec::new();


### PR DESCRIPTION
@porcuquine 
I reverse-engineered your scheduler PR and created a new one with some changes I had in mind. It should be roughly the same with yours, at least the protocol should match with your idea.
I also wrote a test that shows this is working properly, at least in a multi-threaded situation. I also tested in manually in a multi-process environment and it is working perfectly.

Notable changes:
- I'm assuming that a task file is only considered to be valid/existing, if it is also locked. An unlocked task file doesn't have any difference with a non-existing task file and it won't show up in the task list when inspecting the file-system.
- Based on the above assumption, I removed parts of the code in which we were supposed to remove the task files of a certain task from devices, after a free device is found and the task is scheduled; and I tried to rely on rust scoping rules for meeting that requirement. The scheduler class no longer needs to keep track of `Process::Own` tasks and `Process::Other` tasks and unlock/remove them when needed. We now have `schedule()` function which keeps all of the lock-files it has created, inside itself, and when `schedule()` function returns/crashes (Either peacefully or because of a crash/error) then we can be sure that all lock files inside it are dropped (Unlocked) so they won't show up in the task list anymore, even though they might not be deleted.
- Based on the above, I removed/combined some of the structs/functions we had earlier and made the codes shorter/simpler.

I have some plans for integrating this interface with bellman/rust-fil-nse-gpu. If you agree with the new interface, I can proceed.