### PR TITLE
feat: refactor tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ fs2 = { version = "0.4.3", optional = true }
 futures = { version = "0.3.5" }
 lazy_static = "1.4.0"
 log = "0.4.8"
-rand = "0.5.0"
-
+rand = "0.7.3"
+tokio-test = "0.2.1"
 # [dev-dependencies]
 tempfile = "3"
 


### PR DESCRIPTION
Changes:

1- I removed most of the lazy_static variables we had and moved them into the tests, other than the Schedulers
2- Instead of writing a big lazy_static scope containing a Scheduler for each test, we use a macro call: `new_scheduler!(...)`
3- `test_schedule_fn` now schedules tasks with random priority order, and in the end, it checks if the tasks are ran in a sorted order
4- In `test_scheduler`, instead of sleeping before throwing new set of tasks, we wait for their channels.
