### PR TITLE
Release SchedulerRoot lock during pauses when scheduling.

### DIFF
--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -356,6 +356,10 @@ impl<'a, R: Resource + Sync + Send> SchedulerRoot<R> {
     }
 
     fn finish_scheduling(&mut self, task_ident: TaskIdent) {
+        // `assigned_tasks` is only used during the scheduling of a task, to prevent a task from being enqueued on more
+        // resources once it has been assigned. If we did not track this, the task might be double scheduled — since its
+        // `TaskFile` is only removed from sibling resource queues when it is first assigned. We can therefore remove
+        // this tracking once we are done scheduling the task, even though it may not yet have been performed.
         self.assigned_tasks.remove(&task_ident);
     }
 }


### PR DESCRIPTION
@keyvank I think this does what is needed to accommodate your `FnOnce` change while also preserving (and fixing — there was a flaw) the desired concurrent behavior. I moved the scheduling loop out of `SchedulerRoot` and into `Scheduler`'s scheduling function. Now the lock on `SchedulerRoot` is released during the pauses — which allows the main scheduling loop to run and potentially schedule the newly-enqueued task. I think this means we can do away with the `Mutex` on the tasks in `own_tasks` (as you originally wanted) and rely on the one on `SchedulerRoot`. There might still be some picky wrinkles to iron out, but I think the general shape of this is okay now. We're gradually winding toward the goal.