### PR TITLE
Avoid repeatedly listing OpenCL platforms, if there are none.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ ocl = { version = "0.19.4", package = "fil-ocl" }
 dirs = "2.0.2"
 sha2 = "0.8.2"
 thiserror = "1.0.10"
+lazy_static = "1.2"

--- a/src/opencl/mod.rs
+++ b/src/opencl/mod.rs
@@ -119,6 +119,7 @@ impl Device {
 
     pub fn all() -> GPUResult<Vec<Device>> {
         let mut all = Vec::new();
+
         for b in &[Brand::Nvidia, Brand::Amd] {
             all.append(&mut Device::by_brand(*b)?);
         }
@@ -330,4 +331,17 @@ macro_rules! call_kernel {
         $(.arg($arg))*
         .run()
     }};
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_device_all() {
+        for _ in 0..10 {
+            let devices = Device::all().unwrap();
+            dbg!(&devices.len());
+        }
+    }
 }


### PR DESCRIPTION
Repeatedly calling `ocl::Platform::list()` is expensive when there are no OpenCL platforms. This was leading to extremely slow tests in CI, since our current workflow involves this call happening many times (at ten seconds each).

For now, a simple way to avoid that problem is to remember (in a lazy static) whether or not we receive an error (which happens in the slow case) and just return an empty list if we did previously. This assumes we won't actually receive errors when listing platforms if there are any, which is a safe assumption for now.