### PR TITLE
Add GPUSelector.

### DIFF
--- a/src/opencl/error.rs
+++ b/src/opencl/error.rs
@@ -8,6 +8,8 @@ pub enum GPUError {
     DeviceNotFound,
     #[error("Device info not available!")]
     DeviceInfoNotAvailable(ocl::enums::DeviceInfo),
+    #[error("Device index out of range!")]
+    DeviceIndexOutOfRange,
     #[error("Program info not available!")]
     ProgramInfoNotAvailable(ocl::enums::ProgramInfo),
     #[error("IO Error: {0}")]


### PR DESCRIPTION
This PR adds support for `GPUSelector` enum for use in specifying a GPU to use (either by BusID or by position within a list of all available devices).

Similar code currently exists in [`neptune`](https://github.com/filecoin-project/neptune). Moving it here will allow `neptune` to depend on behavior here for GPU selection.

The next step will be to support similar selection in Bellman. The goal is to unify GPU device selection across all repos relying on `rust-gpu-tools`. Once that is accomplished, we can focus on eliminating problematic behavior from the unified implementation.