### PR TITLE
refactor: devices are now a vector

### DIFF
--- a/src/opencl/mod.rs
+++ b/src/opencl/mod.rs
@@ -3,7 +3,7 @@ mod utils;
 
 pub use error::*;
 use sha2::{Digest, Sha256};
-use std::fmt::Write;
+use std::fmt::{self, Write};
 use std::hash::{Hash, Hasher};
 
 pub type BusId = u32;
@@ -19,16 +19,25 @@ pub enum Brand {
 }
 
 impl Brand {
-    pub fn platform_name(&self) -> &'static str {
-        match self {
+    /// Returns a brand by name if it exists
+    fn by_name(name: &str) -> Option<Self> {
+        match name {
+            "NVIDIA CUDA" => Some(Self::Nvidia),
+            "AMD Accelerated Parallel Processing" => Some(Self::Amd),
+            "Apple" => Some(Self::Apple),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Brand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let brand = match self {
             Brand::Nvidia => "NVIDIA CUDA",
             Brand::Amd => "AMD Accelerated Parallel Processing",
             Brand::Apple => "Apple",
-        }
-    }
-
-    fn all() -> Vec<Brand> {
-        vec![Brand::Nvidia, Brand::Amd, Brand::Apple]
+        };
+        write!(f, "{}", brand)
     }
 }
 
@@ -120,21 +129,13 @@ impl Device {
         self.bus_id
     }
 
-    /// Return all available GPU devices of supported brands, ordered by brand as
-    /// defined by `Brand::all()`.
+    /// Return all available GPU devices of supported brands.
     pub fn all() -> Vec<&'static Device> {
         Self::all_iter().collect()
     }
 
-    pub fn all_iter() -> impl Iterator<Item = &'static Device> {
-        Brand::all()
-            .into_iter()
-            .filter_map(|brand| utils::DEVICES.get(&brand))
-            .flatten()
-    }
-
     pub fn by_bus_id(bus_id: BusId) -> GPUResult<&'static Device> {
-        Device::all_iter()
+        Self::all_iter()
             .find(|d| match d.bus_id {
                 Some(id) => bus_id == id,
                 None => false,
@@ -142,12 +143,12 @@ impl Device {
             .ok_or(GPUError::DeviceNotFound)
     }
 
-    pub fn by_brand(brand: Brand) -> Option<&'static Vec<Device>> {
-        utils::DEVICES.get(&brand)
-    }
-
     pub fn cl_device_id(&self) -> ocl::ffi::cl_device_id {
         self.device.as_core().as_raw()
+    }
+
+    fn all_iter() -> impl Iterator<Item = &'static Device> {
+        utils::DEVICES.iter()
     }
 }
 
@@ -168,7 +169,7 @@ impl GPUSelector {
 
     pub fn get_device(&self) -> Option<&'static Device> {
         match self {
-            GPUSelector::BusId(bus_id) => Device::all_iter().find(|d| d.bus_id == Some(*bus_id)),
+            GPUSelector::BusId(bus_id) => Device::by_bus_id(*bus_id).ok(),
             GPUSelector::Index(index) => get_device_by_index(*index),
         }
     }

--- a/src/opencl/utils.rs
+++ b/src/opencl/utils.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::convert::TryInto;
 
 use lazy_static::lazy_static;
@@ -85,71 +84,63 @@ pub fn cache_path(device: &Device, cl_source: &str) -> std::io::Result<std::path
 }
 
 lazy_static! {
-    pub static ref PLATFORMS: Vec<ocl::Platform> = ocl::Platform::list().unwrap_or_default();
-    pub static ref DEVICES: HashMap<Brand, Vec<Device>> = build_device_list();
+    pub(crate) static ref DEVICES: Vec<Device> = build_device_list();
 }
 
-pub fn find_platform(platform_name: &str) -> ocl::Result<Option<&ocl::Platform>> {
-    let platform = PLATFORMS.iter().find(|&p| match p.clone().name() {
-        Ok(p) => p == *platform_name,
-        Err(_) => false,
-    });
-    Ok(platform)
-}
+fn build_device_list() -> Vec<Device> {
+    let mut all_devices = Vec::new();
+    let platforms: Vec<ocl::Platform> = ocl::Platform::list().unwrap_or_default();
 
-fn build_device_list() -> HashMap<Brand, Vec<Device>> {
-    let brands = Brand::all();
-    let mut map = HashMap::with_capacity(brands.len());
-
-    for brand in brands.into_iter() {
-        match find_platform(brand.platform_name()) {
-            Ok(Some(platform)) => {
-                let devices = ocl::Device::list(platform, Some(ocl::core::DeviceType::GPU))
-                    .map_err(Into::into)
-                    .and_then(|devices| {
-                        devices
-                            .into_iter()
-                            .filter(|d| {
-                                if let Ok(vendor) = d.vendor() {
-                                    match vendor.as_str() {
-                                        // Only use devices from the accepted vendors ...
-                                        AMD_DEVICE_VENDOR_STRING | NVIDIA_DEVICE_VENDOR_STRING => {
-                                            // ... which are available.
-                                            return d.is_available().unwrap_or(false);
-                                        }
-                                        _ => (),
-                                    }
-                                }
-                                false
-                            })
-                            .map(|d| -> GPUResult<_> {
-                                Ok(Device {
-                                    brand,
-                                    name: d.name()?,
-                                    memory: get_memory(d)?,
-                                    bus_id: utils::get_bus_id(d).ok(),
-                                    platform: *platform,
-                                    device: d,
-                                })
-                            })
-                            .collect::<GPUResult<Vec<_>>>()
-                    });
-                match devices {
-                    Ok(devices) => {
-                        map.insert(brand, devices);
-                    }
-                    Err(err) => {
-                        warn!("Unable to retrieve devices for {:?}: {:?}", brand, err);
-                    }
-                }
+    for platform in platforms.iter() {
+        let platform_name = match platform.name() {
+            Ok(pn) => pn,
+            Err(error) => {
+                warn!("Cannot get platform name: {:?}", error);
+                continue;
             }
-            Ok(None) => {}
-            Err(err) => {
-                warn!("Platform issue for brand {:?}: {:?}", brand, err);
+        };
+        if let Some(brand) = Brand::by_name(&platform_name) {
+            let devices = ocl::Device::list(platform, Some(ocl::core::DeviceType::GPU))
+                .map_err(Into::into)
+                .and_then(|devices| {
+                    devices
+                        .into_iter()
+                        .filter(|d| {
+                            if let Ok(vendor) = d.vendor() {
+                                match vendor.as_str() {
+                                    // Only use devices from the accepted vendors ...
+                                    AMD_DEVICE_VENDOR_STRING | NVIDIA_DEVICE_VENDOR_STRING => {
+                                        // ... which are available.
+                                        return d.is_available().unwrap_or(false);
+                                    }
+                                    _ => (),
+                                }
+                            }
+                            false
+                        })
+                        .map(|d| -> GPUResult<_> {
+                            Ok(Device {
+                                brand,
+                                name: d.name()?,
+                                memory: get_memory(d)?,
+                                bus_id: utils::get_bus_id(d).ok(),
+                                platform: *platform,
+                                device: d,
+                            })
+                        })
+                        .collect::<GPUResult<Vec<_>>>()
+                });
+            match devices {
+                Ok(mut devices) => {
+                    all_devices.append(&mut devices);
+                }
+                Err(err) => {
+                    warn!("Unable to retrieve devices for {:?}: {:?}", brand, err);
+                }
             }
         }
     }
 
-    debug!("loaded devices: {:?}", map);
-    map
+    debug!("loaded devices: {:?}", all_devices);
+    all_devices
 }


### PR DESCRIPTION
Prior to this change the devices were a hash map where the key is the
brand and the value are the corresponding devices. This was an
unnecessary indirection as we only care about the devices. The devices
still contain the brand information, so you can filter a certain
brand by looping through the devices.

This commit also makes `DEVICES` only public to the crate and removes
the global public `PLATFORMS`.

These code change won't break the current upstream users bellperson and
neptune. On both the CI passes:

 - https://app.circleci.com/pipelines/github/filecoin-project/bellperson/1073/workflows/8e247652-4dae-4de9-b70e-1c62994da2f8
 - https://app.circleci.com/pipelines/github/filecoin-project/neptune/562/workflows/f1f9a9f2-ec30-4cb3-a0f8-ee84457f239a