### PR TITLE
fix: make error types public again

### DIFF
--- a/src/opencl/mod.rs
+++ b/src/opencl/mod.rs
@@ -4,7 +4,7 @@ mod utils;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use error::{GPUError, GPUResult};
+pub use error::{GPUError, GPUResult};
 
 pub type BusId = u32;
 


### PR DESCRIPTION
The last commit accidentally made the error types private.