### PR TITLE
chore: improve Clippy on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,6 @@ jobs:
       - run: cargo fetch
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
-      - run: rustup component add rustfmt-preview
-      - run: rustup component add clippy-preview
       - run: rustc --version
       - run: rm -rf .git
       - persist_to_workspace:
@@ -101,7 +99,7 @@ jobs:
       - run: source $BASH_ENV
       - run:
           name: Run cargo clippy
-          command: cargo clippy --all-features
+          command: cargo clippy --all-features --all-targets -- -D warnings
 
   build:
     executor: default


### PR DESCRIPTION
Clippy is run on CI, but even if there are warnings, the CI doesn't
fail. With this commit the CI fails when there are Clippy warnings.
It would now run Clippy on all the code (also benchmarks and examples).