### PR TITLE
feat: replace `Brand` with `Vendor`

### DIFF
--- a/src/opencl/error.rs
+++ b/src/opencl/error.rs
@@ -18,8 +18,8 @@ pub enum GPUError {
     KernelNotFound(String),
     #[error("IO Error: {0}")]
     IO(#[from] std::io::Error),
-    #[error("Cannot get bus ID for device with vendor {0}")]
-    MissingBusId(String),
+    #[error("Vendor {0} is not supported.")]
+    UnsupportedVendor(String),
 }
 
 #[allow(clippy::upper_case_acronyms)]


### PR DESCRIPTION
The `Brand` was related to the platform. On Macs with an AMD graphics
card, it would return `Apple`. This is not really helpful, therefore
change it to `Vendor`, which will always contain the Vendor of the
graphics card.

BREAKING CHANGE: `Brand` is removed, use `Vendor` instead.