### PR TITLE
test: improve device test

### DIFF
--- a/src/opencl/mod.rs
+++ b/src/opencl/mod.rs
@@ -513,10 +513,11 @@ mod test {
 
     #[test]
     fn test_device_all() {
-        for _ in 0..10 {
-            let devices = Device::all();
-            dbg!(&devices.len());
+        let devices = Device::all();
+        for device in devices.iter() {
+            println!("device: {:?}", device);
         }
+        assert!(!devices.is_empty(), "No supported GPU found.");
     }
 
     #[test]


### PR DESCRIPTION
This library needs a working GPU, so it's OK to fail if there is
none. Also print out the devices that were found, this is useful
for debugging purpose as now you can see the detected devices
with running:

    cargo test opencl::test::test_device_all -- --nocapture