### PR TITLE
fix: identify AMD cards correctly

### DIFF
--- a/src/opencl/utils.rs
+++ b/src/opencl/utils.rs
@@ -17,7 +17,7 @@ use super::{Device, DeviceUuid, GPUError, GPUResult, PciId, Vendor, CL_UUID_SIZE
 ///     └└-- Bus ID
 /// ```
 fn get_pci_id(device: &opencl3::device::Device) -> GPUResult<PciId> {
-    let vendor = Vendor::try_from(device.vendor()?.as_str())?;
+    let vendor = Vendor::try_from(device.vendor_id()?)?;
     let id = match vendor {
         Vendor::Amd => {
             let topo = device.topology_amd()?;
@@ -87,9 +87,9 @@ fn build_device_list() -> Vec<Device> {
                     .into_iter()
                     .map(opencl3::device::Device::new)
                     .filter_map(|device| {
-                        if let Ok(vendor_string) = device.vendor() {
+                        if let Ok(vendor_id) = device.vendor_id() {
                             // Only use devices from the accepted vendors ...
-                            let vendor = Vendor::try_from(&vendor_string[..]).ok()?;
+                            let vendor = Vendor::try_from(vendor_id).ok()?;
                             // ... which are available.
                             if device.available().unwrap_or(0) == 0 {
                                 return None;


### PR DESCRIPTION
There were problems identifying AMD cards correctly [1]. The reason is
that the code so far was tested with integrated AMD GPUs on Apple
devices, which report "AMD" as vendor name. Though usually the vendor
name of AMD is "Advanced Micro Devices, Inc.". Both should be supported.

As the code needed to change anyway, I decided to switch from string
identifiers to using the vendor ID, which is a numeric value. This
should lead to a more robust identification.

This commit also changes the `Display` string for AMD, it's now using
the more common "Advanced Micro Devices, Inc." instead of "AMD".

[1]: https://github.com/filecoin-project/rust-gpu-tools/issues/45