### PR TITLE
docs: add more API documentation

### DIFF
--- a/src/opencl/mod.rs
+++ b/src/opencl/mod.rs
@@ -1,3 +1,5 @@
+//! The OpenCL specific implementation of a [`Buffer`], [`Device`], [`Program`] and [`Kernel`].
+
 mod error;
 mod utils;
 
@@ -34,7 +36,7 @@ pub type cl_device_id = opencl3::types::cl_device_id;
 ///
 /// It is the first two identifiers of e.g. `lspci`:
 ///
-/// ```ignore
+/// ```text
 ///     4e:00.0 VGA compatible controller
 ///     || └└-- Device ID
 ///     └└-- Bus ID
@@ -202,15 +204,19 @@ impl fmt::Display for Vendor {
     }
 }
 
+/// A Buffer to be used for sending and receiving data to/from the GPU.
 pub struct Buffer<T> {
     buffer: opencl3::memory::Buffer<T>,
+    /// The number of T-sized elements.
     length: usize,
 }
 
+/// OpenCL specific device.
 #[derive(Debug, Clone)]
 pub struct Device {
     vendor: Vendor,
     name: String,
+    /// The total memory of the GPU in bytes.
     memory: u64,
     pci_id: PciId,
     uuid: Option<DeviceUuid>,
@@ -233,13 +239,17 @@ impl PartialEq for Device {
 impl Eq for Device {}
 
 impl Device {
+    /// Returns the [`Vendor`] of the GPU.
     pub fn vendor(&self) -> Vendor {
         self.vendor
     }
 
+    /// Returns the name of the GPU, e.g. "GeForce RTX 3090".
     pub fn name(&self) -> String {
         self.name.clone()
     }
+
+    /// Returns the memory of the GPU in bytes.
     pub fn memory(&self) -> u64 {
         self.memory
     }
@@ -250,10 +260,14 @@ impl Device {
             Err(_) => Err(GPUError::DeviceInfoNotAvailable(CL_DEVICE_ENDIAN_LITTLE)),
         }
     }
+
+    /// Returns the PCI-ID of the GPU, see the [`PciId`] type for more information.
     pub fn pci_id(&self) -> PciId {
         self.pci_id
     }
 
+    /// Returns the PCI-ID of the GPU if available, see the [`DeviceUuid`] type for more
+    /// information.
     pub fn uuid(&self) -> Option<DeviceUuid> {
         self.uuid
     }
@@ -296,11 +310,20 @@ impl Device {
         utils::DEVICES.iter()
     }
 
+    /// Low-level access to the device identifier.
+    ///
+    /// It changes when the device is initialized and should only be used to interact with other
+    /// libraries that work on the lowest OpenCL level.
     pub fn cl_device_id(&self) -> cl_device_id {
         self.device.id()
     }
 }
 
+/// Abstraction that contains everything to run an OpenCL kernel on a GPU.
+///
+/// The majority of methods are the same as [`crate::cuda::Program`], so you can write code using this
+/// API, which will then work with OpenCL as well as CUDA kernels.
+#[allow(broken_intra_doc_links)]
 pub struct Program {
     device_name: String,
     queue: CommandQueue,
@@ -309,10 +332,12 @@ pub struct Program {
 }
 
 impl Program {
+    /// Returns the name of the GPU, e.g. "GeForce RTX 3090".
     pub fn device_name(&self) -> &str {
         &self.device_name
     }
 
+    /// Creates a program for a specific device from OpenCL source code.
     pub fn from_opencl(device: &Device, src: &str) -> GPUResult<Program> {
         let cached = utils::cache_path(device, src)?;
         if std::path::Path::exists(&cached) {
@@ -348,6 +373,7 @@ impl Program {
         }
     }
 
+    /// Creates a program for a specific device from a compiled OpenCL binary.
     pub fn from_binary(device: &Device, bin: Vec<u8>) -> GPUResult<Program> {
         let context = Context::from_device(&device.device)?;
         let bins = vec![&bin[..]];
@@ -374,6 +400,9 @@ impl Program {
         })
     }
 
+    /// Creates a new buffer that can be used for input/output with the GPU.
+    ///
+    /// The `length` is the number of elements to create.
     pub fn create_buffer<T>(&self, length: usize) -> GPUResult<Buffer<T>> {
         assert!(length > 0);
         let buff = opencl3::memory::Buffer::create(
@@ -414,6 +443,9 @@ impl Program {
         })
     }
 
+    /// Puts data from an existing buffer onto the GPU.
+    ///
+    /// The `offset` is in number of `T` sized elements, not in their byte size.
     pub fn write_from_buffer<T>(
         &self,
         buffer: &Buffer<T>,
@@ -432,6 +464,9 @@ impl Program {
         Ok(())
     }
 
+    /// Reads data from the GPU into an existing buffer.
+    ///
+    /// The `offset` is in number of `T` sized elements, not in their byte size.
     pub fn read_into_buffer<T>(
         &self,
         buffer: &Buffer<T>,
@@ -462,7 +497,13 @@ impl Program {
     }
 }
 
+/// Abstraction for kernel arguments.
+///
+/// The kernel doesn't support being called with custom types, hence some conversion might be
+/// needed. This trait enables automatic coversions, so that any type implementing it can be
+/// passed into a [`Kernel`].
 pub trait KernelArgument<'a> {
+    /// Apply the kernel argument to the kernel.
     fn push(&self, kernel: &mut Kernel<'a>);
 }
 
@@ -484,11 +525,14 @@ impl KernelArgument<'_> for u32 {
     }
 }
 
+/// A local buffer.
 pub struct LocalBuffer<T> {
+    /// The number of T sized elements.
     length: usize,
     _phantom: std::marker::PhantomData<T>,
 }
 impl<T> LocalBuffer<T> {
+    /// Returns a new buffer of the specified `length`.
     pub fn new(length: usize) -> Self {
         LocalBuffer::<T> {
             length,
@@ -505,6 +549,7 @@ impl<T> KernelArgument<'_> for LocalBuffer<T> {
     }
 }
 
+/// A kernel that can be executed.
 #[derive(Debug)]
 pub struct Kernel<'a> {
     builder: ExecuteKernel<'a>,
@@ -512,10 +557,13 @@ pub struct Kernel<'a> {
 }
 
 impl<'a> Kernel<'a> {
+    /// Set a kernel argument.
     pub fn arg<T: KernelArgument<'a>>(mut self, t: &T) -> Self {
         t.push(&mut self);
         self
     }
+
+    /// Actually run the kernel.
     pub fn run(mut self) -> GPUResult<()> {
         self.builder.enqueue_nd_range(&self.queue)?;
         Ok(())

--- a/src/opencl/utils.rs
+++ b/src/opencl/utils.rs
@@ -11,7 +11,7 @@ use super::{Device, DeviceUuid, GPUError, GPUResult, PciId, Vendor, CL_UUID_SIZE
 ///
 /// It is the first two identifiers of e.g. `lspci`:
 ///
-/// ```ignore
+/// ```text
 ///     4e:00.0 VGA compatible controller
 ///     || └└-- Device ID
 ///     └└-- Bus ID
@@ -72,6 +72,10 @@ lazy_static! {
     pub(crate) static ref DEVICES: Vec<Device> = build_device_list();
 }
 
+/// Get a list of all available and supported devices.
+///
+/// If there is a failure retrieving a device, it won't lead to a hard error, but an error will be
+/// logged and the corresponding device won't be available.
 fn build_device_list() -> Vec<Device> {
     let mut all_devices = Vec::new();
     let platforms: Vec<_> = opencl3::platform::get_platforms().unwrap_or_default();


### PR DESCRIPTION
The API documentation isn't complete yet, the reason is that some
methods will be removed in future commits, hence there's no need
to document them now.