### PR TITLE
fix: make it linkable on MacOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ sha2 = "0.8.2"
 thiserror = "1.0.10"
 lazy_static = "1.2"
 log = "0.4.11"
-opencl3 = "0.2.4"
+opencl3 = { version = "0.4.1", default-features = false, features = ["CL_VERSION_1_2"] }
 hex = "0.4.3"

--- a/src/opencl/mod.rs
+++ b/src/opencl/mod.rs
@@ -261,11 +261,9 @@ impl Device {
         self.memory
     }
     pub fn is_little_endian(&self) -> GPUResult<bool> {
-        match self.device.endian_little() {
-            Ok(0) => Ok(false),
-            Ok(_) => Ok(true),
-            Err(_) => Err(GPUError::DeviceInfoNotAvailable(CL_DEVICE_ENDIAN_LITTLE)),
-        }
+        self.device
+            .endian_little()
+            .map_err(|_| GPUError::DeviceInfoNotAvailable(CL_DEVICE_ENDIAN_LITTLE))
     }
 
     /// Returns the PCI-ID of the GPU, see the [`PciId`] type for more information.
@@ -461,12 +459,12 @@ impl Program {
     ) -> GPUResult<()> {
         assert!(offset + data.len() <= buffer.length, "Buffer is too small");
 
-        let buff = buffer
+        let mut buff = buffer
             .buffer
             .create_sub_buffer(CL_MEM_READ_WRITE, offset, data.len())?;
 
         self.queue
-            .enqueue_write_buffer(&buff, CL_BLOCKING, 0, data, &[])?;
+            .enqueue_write_buffer(&mut buff, CL_BLOCKING, 0, data, &[])?;
 
         Ok(())
     }

--- a/src/opencl/utils.rs
+++ b/src/opencl/utils.rs
@@ -95,7 +95,7 @@ fn build_device_list() -> Vec<Device> {
                             // Only use devices from the accepted vendors ...
                             let vendor = Vendor::try_from(vendor_id).ok()?;
                             // ... which are available.
-                            if device.available().unwrap_or(0) == 0 {
+                            if !device.available().unwrap_or(false) {
                                 return None;
                             }
 


### PR DESCRIPTION
With the 0.4 release of `opencl` it's now possible to compile with
OpenCL 1.2 features only. This is needed for MacOS as the linking
would fail if the library contains symbols from newer OpenCL verisons.