### PR TITLE
fix: back to ocl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ sha2 = "0.8.2"
 thiserror = "1.0.10"
 lazy_static = "1.2"
 log = "0.4.11"
-opencl3 = { version = "0.4.1", default-features = false, features = ["CL_VERSION_1_2"] }
+ocl = { version = "0.19.4", package = "fil-ocl" }
 hex = "0.4.3"

--- a/src/opencl/error.rs
+++ b/src/opencl/error.rs
@@ -1,19 +1,14 @@
-use opencl3::{device::DeviceInfo, error_codes::ClError, program::ProgramInfo};
-
 #[derive(thiserror::Error, Debug)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum GPUError {
-    #[error("Opencl3 Error: {0}{}", match .1 {
-       Some(message) => format!(" {}", message),
-       None => "".to_string(),
-    })]
-    Opencl3(ClError, Option<String>),
+    #[error("Ocl Error: {0}")]
+    Ocl(ocl::Error),
     #[error("Device not found!")]
     DeviceNotFound,
     #[error("Device info not available!")]
-    DeviceInfoNotAvailable(DeviceInfo),
+    DeviceInfoNotAvailable(ocl::enums::DeviceInfo),
     #[error("Program info not available!")]
-    ProgramInfoNotAvailable(ProgramInfo),
+    ProgramInfoNotAvailable(ocl::enums::ProgramInfo),
     #[error("Kernel with name {0} not found!")]
     KernelNotFound(String),
     #[error("IO Error: {0}")]
@@ -28,8 +23,14 @@ pub enum GPUError {
 #[allow(dead_code)]
 pub type GPUResult<T> = std::result::Result<T, GPUError>;
 
-impl From<ClError> for GPUError {
-    fn from(error: ClError) -> Self {
-        GPUError::Opencl3(error, None)
+impl From<ocl::Error> for GPUError {
+    fn from(error: ocl::Error) -> Self {
+        GPUError::Ocl(error)
+    }
+}
+
+impl From<ocl::core::Error> for GPUError {
+    fn from(error: ocl::core::Error) -> Self {
+        GPUError::Ocl(error.into())
     }
 }

--- a/src/opencl/utils.rs
+++ b/src/opencl/utils.rs
@@ -2,10 +2,19 @@ use std::convert::{TryFrom, TryInto};
 
 use lazy_static::lazy_static;
 use log::{debug, warn};
-use opencl3::device::DeviceInfo::CL_DEVICE_GLOBAL_MEM_SIZE;
 use sha2::{Digest, Sha256};
 
 use super::{Device, DeviceUuid, GPUError, GPUResult, PciId, Vendor, CL_UUID_SIZE_KHR};
+
+#[repr(C)]
+#[derive(Debug, Clone, Default)]
+struct cl_amd_device_topology {
+    r#type: u32,
+    unused: [u8; 17],
+    bus: u8,
+    device: u8,
+    function: u8,
+}
 
 /// The PCI-ID is the combination of the PCI Bus ID and PCI Device ID.
 ///
@@ -16,26 +25,44 @@ use super::{Device, DeviceUuid, GPUError, GPUResult, PciId, Vendor, CL_UUID_SIZE
 ///     || └└-- Device ID
 ///     └└-- Bus ID
 /// ```
-fn get_pci_id(device: &opencl3::device::Device) -> GPUResult<PciId> {
-    let vendor = Vendor::try_from(device.vendor_id()?)?;
+fn get_pci_id(device: &ocl::Device) -> GPUResult<PciId> {
+    let vendor = Vendor::try_from(get_vendor_id(device)?)?;
     let id = match vendor {
         Vendor::Amd => {
-            let topo = device.topology_amd()?;
+            const CL_DEVICE_TOPOLOGY_AMD: u32 = 0x4037;
+            let result = device.info_raw(CL_DEVICE_TOPOLOGY_AMD)?;
+            let size = std::mem::size_of::<cl_amd_device_topology>();
+            assert_eq!(result.len(), size);
+            let mut topo = cl_amd_device_topology::default();
+            unsafe {
+                std::slice::from_raw_parts_mut(
+                    &mut topo as *mut cl_amd_device_topology as *mut u8,
+                    size,
+                )
+                .copy_from_slice(&result);
+            }
             let bus_id = topo.bus as u16;
             let device_id = topo.device as u16;
             (bus_id << 8) | device_id
         }
         Vendor::Nvidia => {
-            let bus_id = device.pci_bus_id_nv()? as u16;
-            let device_id = device.pci_slot_id_nv()? as u16;
+            const CL_DEVICE_PCI_BUS_ID_NV: u32 = 0x4008;
+            let bus_id_result = device.info_raw(CL_DEVICE_PCI_BUS_ID_NV)?;
+            let bus_id = u32::from_le_bytes(bus_id_result[..].try_into().unwrap()) as u16;
+
+            const CL_DEVICE_PCI_SLOT_ID_NV: u32 = 0x4009;
+            let device_id_result = device.info_raw(CL_DEVICE_PCI_SLOT_ID_NV)?;
+            let device_id = u32::from_le_bytes(device_id_result[..].try_into().unwrap()) as u16;
             (bus_id << 8) | device_id
         }
     };
     Ok(id.into())
 }
 
-fn get_uuid(device: &opencl3::device::Device) -> GPUResult<DeviceUuid> {
-    let uuid_vec = device.uuid_khr()?;
+fn get_uuid(device: &ocl::Device) -> GPUResult<DeviceUuid> {
+    const CL_UUID_SIZE_KHR: usize = 16;
+    const CL_DEVICE_UUID_KHR: u32 = 0x106A;
+    let uuid_vec = device.info_raw(CL_DEVICE_UUID_KHR)?;
     assert_eq!(
         uuid_vec.len(),
         CL_UUID_SIZE_KHR,
@@ -63,9 +90,21 @@ pub fn cache_path(device: &Device, cl_source: &str) -> std::io::Result<std::path
     Ok(path.join(filename))
 }
 
-fn get_memory(d: &opencl3::device::Device) -> GPUResult<u64> {
-    d.global_mem_size()
-        .map_err(|_| GPUError::DeviceInfoNotAvailable(CL_DEVICE_GLOBAL_MEM_SIZE))
+fn get_memory(d: &ocl::Device) -> GPUResult<u64> {
+    match d.info(ocl::enums::DeviceInfo::GlobalMemSize)? {
+        ocl::enums::DeviceInfoResult::GlobalMemSize(sz) => Ok(sz),
+        _ => Err(GPUError::DeviceInfoNotAvailable(
+            ocl::enums::DeviceInfo::GlobalMemSize,
+        )),
+    }
+}
+
+fn get_vendor_id(d: &ocl::Device) -> GPUResult<u32> {
+    match d.info(ocl::enums::DeviceInfo::VendorId) {
+        Ok(ocl::enums::DeviceInfoResult::VendorId(id)) => Ok(id),
+        Err(error) => Err(error.into()),
+        _ => unreachable!(),
+    }
 }
 
 lazy_static! {
@@ -78,24 +117,22 @@ lazy_static! {
 /// logged and the corresponding device won't be available.
 fn build_device_list() -> Vec<Device> {
     let mut all_devices = Vec::new();
-    let platforms: Vec<_> = opencl3::platform::get_platforms().unwrap_or_default();
+    let platforms: Vec<_> = ocl::Platform::list().unwrap_or_default();
 
     let mut devices_without_pci_id = Vec::new();
 
     for platform in platforms.iter() {
-        let devices = platform
-            .get_devices(opencl3::device::CL_DEVICE_TYPE_GPU)
+        let devices = ocl::Device::list(platform, Some(ocl::core::DeviceType::GPU))
             .map_err(Into::into)
             .and_then(|devices| {
                 devices
                     .into_iter()
-                    .map(opencl3::device::Device::new)
                     .filter_map(|device| {
-                        if let Ok(vendor_id) = device.vendor_id() {
+                        if let Ok(vendor_id) = get_vendor_id(&device) {
                             // Only use devices from the accepted vendors ...
                             let vendor = Vendor::try_from(vendor_id).ok()?;
                             // ... which are available.
-                            if !device.available().unwrap_or(false) {
+                            if !device.is_available().unwrap_or(false) {
                                 return None;
                             }
 
@@ -121,6 +158,7 @@ fn build_device_list() -> Vec<Device> {
                                         memory,
                                         pci_id,
                                         uuid,
+                                        platform: *platform,
                                         device,
                                     }));
                                 }
@@ -134,6 +172,7 @@ fn build_device_list() -> Vec<Device> {
                                         memory,
                                         pci_id,
                                         uuid,
+                                        platform: *platform,
                                         device,
                                     });
                                     return None;


### PR DESCRIPTION
Using `opencl3` introduced a regression that still has to be identified.
Meanwhile switch back to `ocl`.