### PR TITLE
feat: add core counts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ hex = "0.4.3"
 
 opencl3 = { version = "0.4.1", default-features = false, features = ["CL_VERSION_1_2"], optional = true }
 rustacuda = { package = "fil-rustacuda", version = "0.1.3", optional = true }
+once_cell = "1.8.0"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ let closures = program_closures!(|program, _args| -> Result<Vec<u32>, GPUError> 
 });
 ```
 
+
+## Environment variables
+
+ - `RUST_GPU_TOOLS_CUSTOM_GPU`
+
+    rust-gpu-tools has a hard-coded list of GPUs and their CUDA core count. If your card is not
+    part of that list, you can add it via `RUST_GPU_TOOLS_CUSTOM_GPU`. The value is a comma
+    separated list of `name:cores`. Example:
+
+        RUST_GPU_TOOLS_CUSTOM_GPU="GeForce RTX 2080 Ti:4352,GeForce GTX 1060:1280"
+
+
 ## License
 
 Licensed under either of

--- a/src/corecounts.rs
+++ b/src/corecounts.rs
@@ -7,9 +7,9 @@ use once_cell::sync::Lazy;
 /// The number of CUDA cores.
 ///
 /// For non CUDA cards, a number is estimated based on the OpenCL compute units is chosen.
-pub static CORE_COUNTS: Lazy<HashMap<String, usize>> = Lazy::new(core_counts);
+pub static CUDA_CORES: Lazy<HashMap<String, usize>> = Lazy::new(cuda_cores);
 
-fn core_counts() -> HashMap<String, usize> {
+fn cuda_cores() -> HashMap<String, usize> {
     let mut core_counts: HashMap<String, usize> = vec![
         // AMD
         ("gfx1010".to_string(), 2560),
@@ -65,26 +65,26 @@ mod tests {
     use std::env;
 
     #[test]
-    fn get_core_count() {
-        let core_counts = super::core_counts();
+    fn get_cuda_cores() {
+        let core_counts = super::cuda_cores();
         let rtx_2080_ti_core_count = *core_counts.get("GeForce RTX 2080 Ti").unwrap();
         assert_eq!(rtx_2080_ti_core_count, 4352);
     }
 
     #[test]
-    fn get_core_count_missing() {
-        let core_counts = super::core_counts();
-        let unknown_core_count = core_counts.get("My Unknown GPU").is_none();
+    fn get_cuda_cores_missing() {
+        let core_counts = super::cuda_cores();
+        let unknown_core_count = core_counts.get("My unknown GPU").is_none();
         assert!(unknown_core_count);
     }
 
     #[test]
-    fn get_core_count_custom() {
+    fn get_cuda_cores_custom() {
         env::set_var(
             "RUST_GPU_TOOLS_CUSTOM_GPU",
             "My custom GPU:12345,My other GPU:4444",
         );
-        let core_counts = super::core_counts();
+        let core_counts = super::cuda_cores();
         let custom_core_count = *core_counts.get("My custom GPU").unwrap();
         assert_eq!(custom_core_count, 12345);
     }

--- a/src/corecounts.rs
+++ b/src/corecounts.rs
@@ -1,0 +1,91 @@
+use std::collections::HashMap;
+use std::env;
+
+use log::info;
+use once_cell::sync::Lazy;
+
+/// The number of CUDA cores.
+///
+/// For non CUDA cards, a number is estimated based on the OpenCL compute units is chosen.
+pub static CORE_COUNTS: Lazy<HashMap<String, usize>> = Lazy::new(core_counts);
+
+fn core_counts() -> HashMap<String, usize> {
+    let mut core_counts: HashMap<String, usize> = vec![
+        // AMD
+        ("gfx1010".to_string(), 2560),
+        // This value was chosen to give (approximately) empirically best performance for a Radeon Pro VII.
+        ("gfx906".to_string(), 7400),
+        // NVIDIA
+        ("Quadro RTX 6000".to_string(), 4608),
+        ("Quadro RTX A6000".to_string(), 10752),
+        ("TITAN RTX".to_string(), 4608),
+        ("Tesla V100".to_string(), 5120),
+        ("Tesla P100".to_string(), 3584),
+        ("Tesla T4".to_string(), 2560),
+        ("Quadro M5000".to_string(), 2048),
+        ("GeForce RTX 3090".to_string(), 10496),
+        ("GeForce RTX 3080".to_string(), 8704),
+        ("GeForce RTX 3070".to_string(), 5888),
+        ("GeForce RTX 2080 Ti".to_string(), 4352),
+        ("GeForce RTX 2080 SUPER".to_string(), 3072),
+        ("GeForce RTX 2080".to_string(), 2944),
+        ("GeForce RTX 2070 SUPER".to_string(), 2560),
+        ("GeForce GTX 1080 Ti".to_string(), 3584),
+        ("GeForce GTX 1080".to_string(), 2560),
+        ("GeForce GTX 2060".to_string(), 1920),
+        ("GeForce GTX 1660 Ti".to_string(), 1536),
+        ("GeForce GTX 1060".to_string(), 1280),
+        ("GeForce GTX 1650 SUPER".to_string(), 1280),
+        ("GeForce GTX 1650".to_string(), 896),
+    ]
+    .into_iter()
+    .collect();
+
+    if let Ok(var) = env::var("RUST_GPU_TOOLS_CUSTOM_GPU") {
+        for card in var.split(',') {
+            let splitted = card.split(':').collect::<Vec<_>>();
+            if splitted.len() != 2 {
+                panic!("Invalid RUST_GPU_TOOLS_CUSTOM_GPU!");
+            }
+            let name = splitted[0].trim().to_string();
+            let cores: usize = splitted[1]
+                .trim()
+                .parse()
+                .expect("Invalid RUST_GPU_TOOLS_CUSTOM_GPU!");
+            info!("Adding \"{}\" to GPU list with {} CUDA cores.", name, cores);
+            core_counts.insert(name, cores);
+        }
+    }
+
+    core_counts
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    #[test]
+    fn get_core_count() {
+        let core_counts = super::core_counts();
+        let rtx_2080_ti_core_count = *core_counts.get("GeForce RTX 2080 Ti").unwrap();
+        assert_eq!(rtx_2080_ti_core_count, 4352);
+    }
+
+    #[test]
+    fn get_core_count_missing() {
+        let core_counts = super::core_counts();
+        let unknown_core_count = core_counts.get("My Unknown GPU").is_none();
+        assert!(unknown_core_count);
+    }
+
+    #[test]
+    fn get_core_count_custom() {
+        env::set_var(
+            "RUST_GPU_TOOLS_CUSTOM_GPU",
+            "My custom GPU:12345,My other GPU:4444",
+        );
+        let core_counts = super::core_counts();
+        let custom_core_count = *core_counts.get("My custom GPU").unwrap();
+        assert_eq!(custom_core_count, 12345);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![warn(missing_docs)]
 
+mod corecounts;
 mod device;
 mod error;
 #[cfg(any(feature = "cuda", feature = "opencl"))]
@@ -20,6 +21,7 @@ pub mod cuda;
 #[cfg(feature = "opencl")]
 pub mod opencl;
 
+pub use corecounts::CORE_COUNTS;
 pub use device::{Device, DeviceUuid, Framework, PciId, UniqueId, Vendor};
 pub use error::GPUError;
 #[cfg(any(feature = "cuda", feature = "opencl"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod cuda;
 #[cfg(feature = "opencl")]
 pub mod opencl;
 
-pub use corecounts::CORE_COUNTS;
+pub use corecounts::CUDA_CORES;
 pub use device::{Device, DeviceUuid, Framework, PciId, UniqueId, Vendor};
 pub use error::GPUError;
 #[cfg(any(feature = "cuda", feature = "opencl"))]


### PR DESCRIPTION
For maxing out a GPU it's sometimes useful to know the number of CUDA cores.
This commit adds a mapping between graphic cards name and their number of
CUDA cores.

For non CUDA cards an appropriate number based on the compute units is chosen.

If your card isn't specified, you can add it to the list via the
`RUST_GPU_TOOLS_CUSTOM_CPU` environment variable. Example:

    RUST_GPU_TOOLS_CUSTOM_GPU="GeForce RTX 2080 Ti:4352,GeForce GTX 1060:1280"

This code was originally developed as part of bellperson:
https://github.com/filecoin-project/bellperson/blob/dcf8a467a05796cf0f7fb9e170b6fc6845b42d9f/src/gpu/utils.rs#L6-L56