### PR TITLE
Avoid Possible Data Race in `add` example

### DIFF
--- a/examples/add.rs
+++ b/examples/add.rs
@@ -38,7 +38,7 @@ pub fn main() {
         let result_buffer = unsafe { program.create_buffer::<u32>(length)? };
 
         // Get the kernel.
-        let kernel = program.create_kernel("add", 8, 4)?;
+        let kernel = program.create_kernel("add", 1, 1)?;
 
         // Execute the kernel.
         kernel
@@ -67,6 +67,6 @@ pub fn main() {
     // Then we run it on OpenCL.
     let opencl_program = opencl(&device);
     let opencl_result = opencl_program.run(closures, ()).unwrap();
-    assert_eq!(cuda_result, [6, 8, 10, 12]);
+    assert_eq!(opencl_result, [6, 8, 10, 12]);
     println!("OpenCL result: {:?}", opencl_result);
 }


### PR DESCRIPTION
Hello, 

I noticed there was a chance of data race happening in `add` example, because

```
dispatched number of work-groups: 8
dispatched work-group sizes: 4
```

as written [here](https://github.com/filecoin-project/rust-gpu-tools/blob/d3b36477c7d2017e2b7ea284fd91342a667835db/examples/add.rs#L41)

Following [this](https://github.com/filecoin-project/rust-gpu-tools/blob/705641f36bedff317c30f1608594ad03f082d7eb/src/opencl/mod.rs#L258-L264) comment, current [implementation](https://github.com/filecoin-project/rust-gpu-tools/blob/d3b36477c7d2017e2b7ea284fd91342a667835db/examples/add.cl#L12-L14) should invoke 32 work-items ( or threads ) and each of them should be executing same loop over 4 input elements and writing to same memory locations, which can be avoided.

This PR fixes it by launching single work-group of width one work-item. 