### PR TITLE
docs: add information about custom core counts to crate doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,19 @@
 //! Abstraction layer for OpenCL and CUDA.
 //!
-//! Feature Flags
+//! Environment variables
+//! ---------------------
+//!
+//! - `RUST_GPU_TOOLS_CUSTOM_GPU`
+//!
+//!    rust-gpu-tools has a hard-coded list of GPUs and their CUDA core count. If your card is not
+//!    part of that list, you can add it via `RUST_GPU_TOOLS_CUSTOM_GPU`. The value is a comma
+//!    separated list of `name:cores`. Example:
+//!
+//!    ```text
+//!    RUST_GPU_TOOLS_CUSTOM_GPU="GeForce RTX 2080 Ti:4352,GeForce GTX 1060:1280"
+//!    ```
+//!
+//! Feature flags
 //! -------------
 //!
 //! There are two [feature flags], `cuda` and `opencl`. By default `opencl` is enabled. You can


### PR DESCRIPTION
Put the information on how to add custom CUDA core counts via an
environment variable to the top level crate docs. This way it can
easily be linked to.