### PR TITLE
feat: add number of compute units to public API

### DIFF
--- a/src/cuda/mod.rs
+++ b/src/cuda/mod.rs
@@ -38,6 +38,8 @@ pub struct Device {
     name: String,
     /// The total memory of the GPU in bytes.
     memory: u64,
+    /// Number of streaming multiprocessors.
+    compute_units: u32,
     pci_id: PciId,
     uuid: Option<DeviceUuid>,
     device: rustacuda::device::Device,
@@ -80,6 +82,11 @@ impl Device {
     /// Returns the memory of the GPU in bytes.
     pub fn memory(&self) -> u64 {
         self.memory
+    }
+
+    /// Returns the number of compute units of the GPU.
+    pub fn compute_units(&self) -> u32 {
+        self.compute_units
     }
 
     /// Returns the PCI-ID of the GPU, see the [`PciId`] type for more information.

--- a/src/cuda/utils.rs
+++ b/src/cuda/utils.rs
@@ -35,6 +35,11 @@ fn get_memory(d: &rustacuda::device::Device) -> GPUResult<u64> {
     Ok(u64::try_from(memory).expect("Platform must be <= 64-bit"))
 }
 
+fn get_compute_units(d: &rustacuda::device::Device) -> GPUResult<u32> {
+    let compute_units = d.get_attribute(rustacuda::device::DeviceAttribute::MultiprocessorCount)?;
+    Ok(u32::try_from(compute_units).expect("The number of units is always positive"))
+}
+
 /// Get a list of all available and supported devices.
 ///
 /// If there is a failure initializing CUDA or retrieving a device, it won't lead to a hard error,
@@ -59,6 +64,7 @@ pub(crate) fn build_device_list() -> (Vec<Device>, CudaContexts) {
                 let vendor = Vendor::Nvidia;
                 let name = device.name()?;
                 let memory = get_memory(&device)?;
+                let compute_units = get_compute_units(&device)?;
                 let uuid = device.uuid().ok().map(Into::into);
                 let context = owned_context.get_unowned();
 
@@ -72,6 +78,7 @@ pub(crate) fn build_device_list() -> (Vec<Device>, CudaContexts) {
                             vendor,
                             name,
                             memory,
+                            compute_units,
                             pci_id,
                             uuid,
                             device,
@@ -85,6 +92,7 @@ pub(crate) fn build_device_list() -> (Vec<Device>, CudaContexts) {
                             vendor,
                             name,
                             memory,
+                            compute_units,
                             pci_id,
                             uuid,
                             device,

--- a/src/device.rs
+++ b/src/device.rs
@@ -233,6 +233,7 @@ pub struct Device {
     vendor: Vendor,
     name: String,
     memory: u64,
+    compute_units: u32,
     // All devices have a PCI ID. It is used as fallback in case there is not UUID.
     pci_id: PciId,
     uuid: Option<DeviceUuid>,
@@ -256,6 +257,11 @@ impl Device {
     /// Returns the memory of the GPU in bytes.
     pub fn memory(&self) -> u64 {
         self.memory
+    }
+
+    /// Returns the number of compute units of the GPU.
+    pub fn compute_units(&self) -> u32 {
+        self.compute_units
     }
 
     /// Returns the best possible unique identifier, a UUID is preferred over a PCI ID.
@@ -354,6 +360,7 @@ fn build_device_list() -> (Vec<Device>, cuda::utils::CudaContexts) {
             vendor: opencl_device.vendor(),
             name: opencl_device.name(),
             memory: opencl_device.memory(),
+            compute_units: opencl_device.compute_units(),
             pci_id: opencl_device.pci_id(),
             uuid: opencl_device.uuid(),
             opencl: Some(opencl_device),
@@ -369,6 +376,10 @@ fn build_device_list() -> (Vec<Device>, cuda::utils::CudaContexts) {
                 {
                     if device.memory() != cuda_devices[ii].memory() {
                         warn!("OpenCL and CUDA report different amounts of memory for a device with the same identifier");
+                        break;
+                    }
+                    if device.compute_units() != cuda_devices[ii].compute_units() {
+                        warn!("OpenCL and CUDA report different amounts of compute units for a device with the same identifier");
                         break;
                     }
                     // Move the CUDA device out of the vector
@@ -388,6 +399,7 @@ fn build_device_list() -> (Vec<Device>, cuda::utils::CudaContexts) {
             vendor: cuda_device.vendor(),
             name: cuda_device.name(),
             memory: cuda_device.memory(),
+            compute_units: cuda_device.compute_units(),
             pci_id: cuda_device.pci_id(),
             uuid: cuda_device.uuid(),
             cuda: Some(cuda_device),
@@ -413,6 +425,7 @@ fn build_device_list() -> (Vec<Device>, ()) {
             vendor: device.vendor(),
             name: device.name(),
             memory: device.memory(),
+            compute_units: device.compute_units(),
             pci_id: device.pci_id(),
             uuid: device.uuid(),
             opencl: Some(device),

--- a/src/opencl/mod.rs
+++ b/src/opencl/mod.rs
@@ -39,6 +39,8 @@ pub struct Device {
     name: String,
     /// The total memory of the GPU in bytes.
     memory: u64,
+    /// The number of parallel compute units.
+    compute_units: u32,
     pci_id: PciId,
     uuid: Option<DeviceUuid>,
     device: opencl3::device::Device,
@@ -80,6 +82,11 @@ impl Device {
     /// Returns the memory of the GPU in bytes.
     pub fn memory(&self) -> u64 {
         self.memory
+    }
+
+    /// Returns the number of compute units of the GPU.
+    pub fn compute_units(&self) -> u32 {
+        self.compute_units
     }
 
     /// Returns the PCI-ID of the GPU, see the [`PciId`] type for more information.

--- a/src/opencl/utils.rs
+++ b/src/opencl/utils.rs
@@ -61,6 +61,11 @@ fn get_memory(d: &opencl3::device::Device) -> GPUResult<u64> {
         .map_err(GPUError::DeviceInfoNotAvailable)
 }
 
+fn get_compute_units(d: &opencl3::device::Device) -> GPUResult<u32> {
+    d.max_compute_units()
+        .map_err(GPUError::DeviceInfoNotAvailable)
+}
+
 /// Get a list of all available and supported devices.
 ///
 /// If there is a failure retrieving a device, it won't lead to a hard error, but an error will be
@@ -98,6 +103,10 @@ pub(crate) fn build_device_list() -> Vec<Device> {
                                 Ok(memory) => memory,
                                 Err(error) => return Some(Err(error)),
                             };
+                            let compute_units = match get_compute_units(&device) {
+                                Ok(units) => units,
+                                Err(error) => return Some(Err(error)),
+                            };
                             let uuid = get_uuid(&device).ok();
 
                             // If a device doesn't have a PCI-ID, add those later to the list of
@@ -108,6 +117,7 @@ pub(crate) fn build_device_list() -> Vec<Device> {
                                         vendor,
                                         name,
                                         memory,
+                                        compute_units,
                                         pci_id,
                                         uuid,
                                         device,
@@ -121,6 +131,7 @@ pub(crate) fn build_device_list() -> Vec<Device> {
                                         vendor,
                                         name,
                                         memory,
+                                        compute_units,
                                         pci_id,
                                         uuid,
                                         device,


### PR DESCRIPTION
It is now possible to get the number of compute units (OpenCL) or
streaming multiprocessors (CUDA) from a `Device`.