### PR TITLE
feat: add logging whether CUDA or OpenCL is used

### DIFF
--- a/src/cuda/mod.rs
+++ b/src/cuda/mod.rs
@@ -15,6 +15,7 @@ use std::ffi::{c_void, CStr, CString};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
+use log::debug;
 use rustacuda::memory::{AsyncCopyDestination, DeviceBuffer};
 use rustacuda::stream::{Stream, StreamFlags};
 
@@ -130,6 +131,7 @@ impl Program {
 
     /// Creates a program for a specific device from a compiled CUDA binary file.
     pub fn from_binary(device: &Device, filename: &CStr) -> GPUResult<Program> {
+        debug!("Creating CUDA program from binary file.");
         rustacuda::context::CurrentContext::set_current(&device.context)?;
         let module = rustacuda::module::Module::load_from_file(filename).map_err(|err| {
             Self::pop_context();
@@ -151,6 +153,7 @@ impl Program {
 
     /// Creates a program for a specific device from a compiled CUDA binary.
     pub fn from_bytes(device: &Device, bytes: &[u8]) -> GPUResult<Program> {
+        debug!("Creating CUDA program from bytes.");
         rustacuda::context::CurrentContext::set_current(&device.context)?;
         let module = rustacuda::module::Module::load_from_bytes(bytes).map_err(|err| {
             Self::pop_context();

--- a/src/opencl/mod.rs
+++ b/src/opencl/mod.rs
@@ -137,6 +137,7 @@ impl Program {
 
     /// Creates a program for a specific device from OpenCL source code.
     pub fn from_opencl(device: &Device, src: &str) -> GPUResult<Program> {
+        debug!("Creating OpenCL program from source.");
         let cached = utils::cache_path(device, src)?;
         if std::path::Path::exists(&cached) {
             let bin = std::fs::read(cached)?;
@@ -181,6 +182,7 @@ impl Program {
 
     /// Creates a program for a specific device from a compiled OpenCL binary.
     pub fn from_binary(device: &Device, bin: Vec<u8>) -> GPUResult<Program> {
+        debug!("Creating OpenCL program from binary.");
         let context = Context::from_device(&device.device)?;
         let bins = vec![&bin[..]];
         let mut program =


### PR DESCRIPTION
If your project can run on both, CUDA and OpenCL, it is useful to know which version is run. To keep the noise low, add debug logging when the program is created, this should only happen less often then kernel invocations.