### PR TITLE
feat: switch to once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ cuda = ["rustacuda"]
 dirs = "5.0.0"
 sha2 = "0.10"
 thiserror = "1.0.10"
-lazy_static = "1.2"
 log = "0.4.11"
 hex = "0.4.3"
 

--- a/src/cuda/utils.rs
+++ b/src/cuda/utils.rs
@@ -7,12 +7,13 @@ use crate::device::{PciId, Vendor};
 use crate::error::{GPUError, GPUResult};
 
 // NOTE vmx 2021-04-14: This is a hack to make sure contexts stay around. We wrap them, so that
-// `Sync` can be implemented. `Sync` is needed for lazy static. These contexts are never used
-// directly, they are only accessed through [`cuda::Device`] which contains an `UnownedContext`.
-// A device cannot have an own context itself, as then it couldn't be cloned, but that is needed
-// for creating the kernels.
+// `Sync` and `Send` can be implemented. `Sync` and `Send` is needed for once_cell. These contexts
+// are never used directly, they are only accessed through [`cuda::Device`] which contains an
+// `UnownedContext`. A device cannot have an own context itself, as then it couldn't be cloned,
+// but that is needed for creating the kernels.
 pub(crate) struct CudaContexts(Vec<rustacuda::context::Context>);
 unsafe impl Sync for CudaContexts {}
+unsafe impl Send for CudaContexts {}
 
 /// The PCI-ID is the combination of the PCI Bus ID and PCI Device ID.
 ///


### PR DESCRIPTION
Prior to this change, we were using `lazy_static`. While this worked, there is a problem if the `lazy_static` `spin_no_std` features gets enabled. It then requires the types used to implement `Send`.

`once_cell` has the same requirement, which was one of the reasons not to use it. Though it makes sense to implement `Send` for the `CudaContexts`. This means that now the more ergonomic `once_cell` can be used.

Fixes #66.