### PR TITLE
chore: redo CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,97 +2,38 @@ version: 2.1
 
 executors:
   default:
+    docker:
+      - image: cimg/rust:1.70
+    resource_class: small
+  gpu:
     machine:
       image: linux-cuda-12:2023.05.1
-    working_directory: ~/gpuci
-    resource_class: gpu.nvidia.medium
-
-restore-workspace: &restore-workspace
-  attach_workspace:
-    at: ~/
-
-restore-cache: &restore-cache
-  restore_cache:
-    keys:
-      - cargo-v0-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
-      - repo-source-{{ .Branch }}-{{ .Revision }}
-
-commands:
-  set-env-path:
-    steps:
-      - run:
-          name: Set the PATH env variable
-          command: |
-            echo 'export PATH="$HOME:~/.cargo/bin:/usr/local/cuda-11.2/bin:$PATH"' | tee --append $BASH_ENV
-            source $BASH_ENV
-
-  test_target:
-    parameters:
-      target:
-        type: string
-    steps:
-      - *restore-workspace
-      - *restore-cache
-      - run:
-          name: Test (<< parameters.target >>)
-          command: TARGET=<< parameters.target >> cargo test
-          no_output_timeout: 15m
+    resource_class: gpu.nvidia.small
 
 jobs:
-
-  cargo_fetch:
-    executor: default
+  test:
+    executor: gpu
     steps:
       - checkout
-      - run: curl https://sh.rustup.rs -sSf | sh -s -- -y
-      - set-env-path
-      - run: echo $BASH_ENV
-      - run: echo $HOME
-      - run: cargo --version
-      - run: rustc --version
       - run:
-          name: Update submodules
-          command: git submodule update --init --recursive
+          name: Install OpenCL
+          command: |
+            sudo apt update
+            sudo apt install ocl-icd-opencl-dev --no-install-recommends --yes
       - run:
-          name: Calculate dependencies
-          command: cargo generate-lockfile
-      - restore_cache:
-          keys:
-            - cargo-v0-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
-      - run: cargo update
-      - run: cargo fetch
-      - run: rustup install $(cat rust-toolchain)
-      - run: rustup default $(cat rust-toolchain)
-      - run: rustc --version
-      - run: rm -rf .git
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - gpuci
-      - save_cache:
-          key: cargo-v0-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
-          paths:
-            - "~/.cargo"
-            - "~/.rustup"
-
-  test_x86_64-unknown-linux-gnu:
-    executor: default
-    steps:
-      - set-env-path
-      - run: sudo apt-get update -y
-      - run: apt-cache search opencl
-      - run: sudo apt install -y ocl-icd-opencl-dev
-      - test_target:
-          target: "x86_64-unknown-linux-gnu"
+          name: Install Rust
+          command: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $(cat rust-toolchain) --profile minimal -y
+      - run:
+          name: Run tests
+          command: cargo test
+      - run:
+          name: Run `add` example
+          command: cargo run --example add
 
   rustfmt:
     executor: default
     steps:
-      - *restore-workspace
-      - *restore-cache
-      - set-env-path
-      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
-      - run: source $BASH_ENV
+      - checkout
       - run:
           name: Run cargo fmt
           command: cargo fmt --all -- --check
@@ -100,9 +41,7 @@ jobs:
   clippy:
     executor: default
     steps:
-      - *restore-workspace
-      - *restore-cache
-      - set-env-path
+      - checkout
       - run:
           name: Run cargo clippy
           command: cargo clippy --all-features --all-targets -- -D warnings
@@ -110,29 +49,15 @@ jobs:
   build:
     executor: default
     steps:
-      - *restore-workspace
-      - *restore-cache
-      - set-env-path
+      - checkout
       - run:
           name: Run cargo release build
           command: cargo build --release
 
-  example:
-    executor: default
-    steps:
-      - *restore-workspace
-      - *restore-cache
-      - set-env-path
-      - run:
-          name: Run `add` example
-          command: cargo run --example add
-
   rustdoc:
     executor: default
     steps:
-      - *restore-workspace
-      - *restore-cache
-      - set-env-path
+      - checkout
       - run:
           name: Run rustdoc
           command: cargo rustdoc --all-features -- -D warnings
@@ -142,22 +67,8 @@ workflows:
 
   test:
     jobs:
-      - cargo_fetch
-      - rustfmt:
-          requires:
-            - cargo_fetch
-      - clippy:
-          requires:
-            - cargo_fetch
-      - test_x86_64-unknown-linux-gnu:
-          requires:
-            - cargo_fetch
-      - build:
-          requires:
-            - cargo_fetch
-      - example:
-          requires:
-            - cargo_fetch
-      - rustdoc:
-          requires:
-            - cargo_fetch
+      - rustfmt
+      - clippy
+      - test
+      - build
+      - rustdoc


### PR DESCRIPTION
Using GPU workers is only needed for running the tests. Use other (way cheaper) machines for the other steps. This reduces the costs by about 7.5x (from around 1300 to 170 credits).

Also the total runtime is about half now.